### PR TITLE
feat: 게시글 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
-  "name": "sns",
+  "name": "sns-board-api",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "sns",
+      "name": "sns-board-api",
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^9.0.0",
         "@nestjs/core": "^9.0.0",
         "@nestjs/jwt": "^9.0.0",
+        "@nestjs/mapped-types": "^1.1.0",
         "@nestjs/platform-express": "^9.0.0",
         "@nestjs/sequelize": "^9.0.0",
         "class-transformer": "^0.5.1",
@@ -1573,6 +1574,25 @@
       },
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.1.0.tgz",
+      "integrity": "sha512-+2kSly4P1QI+9eGt+/uGyPdEG1hVz7nbpqPHWZVYgoqz8eOHljpXPag+UCVRw9zo2XCu4sgNUIGe8Uk0+OvUQg==",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.8 || ^8.0.0 || ^9.0.0",
+        "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0",
+        "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/platform-express": {
@@ -10469,6 +10489,12 @@
         "@types/jsonwebtoken": "8.5.8",
         "jsonwebtoken": "8.5.1"
       }
+    },
+    "@nestjs/mapped-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.1.0.tgz",
+      "integrity": "sha512-+2kSly4P1QI+9eGt+/uGyPdEG1hVz7nbpqPHWZVYgoqz8eOHljpXPag+UCVRw9zo2XCu4sgNUIGe8Uk0+OvUQg==",
+      "requires": {}
     },
     "@nestjs/platform-express": {
       "version": "9.1.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/jwt": "^9.0.0",
+    "@nestjs/mapped-types": "^1.1.0",
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/sequelize": "^9.0.0",
     "class-transformer": "^0.5.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { SequelizeModule } from '@nestjs/sequelize';
 import { AppService } from './app.service';
 import { UsersModule } from './users/users.module';
 import { Users } from './users/users.model';
+import { BoardsModule } from './boards/boards.module';
 const dotenv = require("dotenv");
 dotenv.config();
 
@@ -25,7 +26,8 @@ dotenv.config();
       },
       timezone: "+09:00"
     }),
-    UsersModule
+    UsersModule,
+    BoardsModule
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,9 @@ import { AppService } from './app.service';
 import { UsersModule } from './users/users.module';
 import { Users } from './users/users.model';
 import { BoardsModule } from './boards/boards.module';
+import { Boards } from './boards/models/boards.model';
+import { HashTags } from './boards/models/hashTag.model';
+import { BoardHashTags } from './boards/models/board_hashTags.model';
 const dotenv = require("dotenv");
 dotenv.config();
 
@@ -17,7 +20,7 @@ dotenv.config();
       username: process.env.MYSQL_USERNAME,
       password: process.env.MYSQL_PASSWORD,
       database: process.env.MYSQL_DATABASE,
-      models: [Users],
+      models: [Users, Boards, HashTags, BoardHashTags],
       dialectOptions: {
         useUTC: false, //for reading from database
         dateStrings: true,

--- a/src/boards/boards.controller.ts
+++ b/src/boards/boards.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('boards')
+export class BoardsController {}

--- a/src/boards/boards.controller.ts
+++ b/src/boards/boards.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Param, Headers, BadRequestException, Patch } from '@nestjs/common';
+import { Controller, Post, Body, Param, Headers, BadRequestException, Patch, Delete } from '@nestjs/common';
 import { BoardsService } from './boards.service';
 import { BoardInfoDTO } from './dto/boardInfo.dto';
 import { UpdateBoardInfoDTO } from './dto/updateBoardInfo.dto';
@@ -42,6 +42,21 @@ export class BoardsController {
       }
 
       const data = await this.BoardsService.update(boardId, boardInfo, Authorization)
+
+      return data
+    } catch (error) {
+      throw new BadRequestException(error.message)
+    }
+  }
+
+  @Delete(":boardId")
+  async delete(@Param("boardId") boardId: number, @Headers("Authorization") Authorization: string) {
+    try {
+      if (!Authorization) {
+        throw new BadRequestException("로그인해주세요.")
+      }
+
+      const data = await this.BoardsService.delete(boardId, Authorization)
 
       return data
     } catch (error) {

--- a/src/boards/boards.controller.ts
+++ b/src/boards/boards.controller.ts
@@ -1,13 +1,15 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Body, BadRequestException } from '@nestjs/common';
 import { BoardsService } from './boards.service';
+import { BoardInfoDTO } from './dto/boardInfo.dto';
 
 @Controller('boards')
 export class BoardsController {
   constructor(private readonly BoardsService: BoardsService) { }
 
   @Post()
-  async create(@Body() boardInfo) {
+  async create(@Body() boardInfo: BoardInfoDTO) {
     const data = await this.BoardsService.create(boardInfo)
+
     return data
   }
 }

--- a/src/boards/boards.controller.ts
+++ b/src/boards/boards.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Post, Body, Param, Headers, BadRequestException, Patch, Delete } from '@nestjs/common';
+import { Controller, Post, Body, Param, Headers, BadRequestException, Patch, Delete, Get, Query } from '@nestjs/common';
 import { BoardsService } from './boards.service';
 import { BoardInfoDTO } from './dto/boardInfo.dto';
+import { QueryInfoDTO } from './dto/queryInfo.dto';
 import { UpdateBoardInfoDTO } from './dto/updateBoardInfo.dto';
 
 @Controller('boards')
@@ -73,6 +74,17 @@ export class BoardsController {
       }
 
       const data = await this.BoardsService.delete(boardId, Authorization)
+
+      return data
+    } catch (error) {
+      throw new BadRequestException(error.message)
+    }
+  }
+
+  @Get()
+  async getAll(@Query() queryInfo: QueryInfoDTO) {
+    try {
+      const data = await this.BoardsService.getAll(queryInfo)
 
       return data
     } catch (error) {

--- a/src/boards/boards.controller.ts
+++ b/src/boards/boards.controller.ts
@@ -1,4 +1,13 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Post, Body } from '@nestjs/common';
+import { BoardsService } from './boards.service';
 
 @Controller('boards')
-export class BoardsController {}
+export class BoardsController {
+  constructor(private readonly BoardsService: BoardsService) { }
+
+  @Post()
+  async create(@Body() boardInfo) {
+    const data = await this.BoardsService.create(boardInfo)
+    return data
+  }
+}

--- a/src/boards/boards.controller.ts
+++ b/src/boards/boards.controller.ts
@@ -8,6 +8,12 @@ export class BoardsController {
 
   @Post()
   async create(@Body() boardInfo: BoardInfoDTO) {
+    boardInfo.hashTags.forEach((hashTag) => {
+      if (hashTag.indexOf("#") !== 0) {
+        throw new BadRequestException("각각의 hashTag에 #이 포함되어야 합니다.")
+      }
+    })
+
     const data = await this.BoardsService.create(boardInfo)
 
     return data

--- a/src/boards/boards.controller.ts
+++ b/src/boards/boards.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Post, Body, Headers, BadRequestException } from '@nestjs/common';
+import { Controller, Post, Body, Param, Headers, BadRequestException, Patch } from '@nestjs/common';
 import { BoardsService } from './boards.service';
 import { BoardInfoDTO } from './dto/boardInfo.dto';
+import { UpdateBoardInfoDTO } from './dto/updateBoardInfo.dto';
 
 @Controller('boards')
 export class BoardsController {
@@ -22,6 +23,25 @@ export class BoardsController {
       })
 
       const data = await this.BoardsService.create(boardInfo, Authorization)
+
+      return data
+    } catch (error) {
+      throw new BadRequestException(error.message)
+    }
+  }
+
+  @Patch(":boardId")
+  async update(
+    @Param("boardId") boardId: number,
+    @Body() boardInfo: UpdateBoardInfoDTO,
+    @Headers("Authorization") Authorization: string
+  ) {
+    try {
+      if (!Authorization) {
+        throw new BadRequestException("로그인해주세요.")
+      }
+
+      const data = await this.BoardsService.update(boardId, boardInfo, Authorization)
 
       return data
     } catch (error) {

--- a/src/boards/boards.controller.ts
+++ b/src/boards/boards.controller.ts
@@ -1,21 +1,31 @@
-import { Controller, Post, Body, BadRequestException } from '@nestjs/common';
+import { Controller, Post, Body, Headers, BadRequestException } from '@nestjs/common';
 import { BoardsService } from './boards.service';
 import { BoardInfoDTO } from './dto/boardInfo.dto';
 
 @Controller('boards')
 export class BoardsController {
-  constructor(private readonly BoardsService: BoardsService) { }
+  constructor(
+    private readonly BoardsService: BoardsService,
+  ) { }
 
   @Post()
-  async create(@Body() boardInfo: BoardInfoDTO) {
-    boardInfo.hashTags.forEach((hashTag) => {
-      if (hashTag.indexOf("#") !== 0) {
-        throw new BadRequestException("각각의 hashTag에 #이 포함되어야 합니다.")
+  async create(@Body() boardInfo: BoardInfoDTO, @Headers("Authorization") Authorization: string) {
+    try {
+      if (!Authorization) {
+        throw new BadRequestException("로그인해주세요.")
       }
-    })
 
-    const data = await this.BoardsService.create(boardInfo)
+      boardInfo.hashTags.forEach((hashTag) => {
+        if (hashTag.indexOf("#") !== 0) {
+          throw new BadRequestException("각각의 hashTag에 #이 포함되어야 합니다.")
+        }
+      })
 
-    return data
+      const data = await this.BoardsService.create(boardInfo, Authorization)
+
+      return data
+    } catch (error) {
+      throw new BadRequestException(error.message)
+    }
   }
 }

--- a/src/boards/boards.controller.ts
+++ b/src/boards/boards.controller.ts
@@ -91,5 +91,16 @@ export class BoardsController {
       throw new BadRequestException(error.message)
     }
   }
+
+  @Get(":boardId")
+  async getOne(@Param("boardId") boardId: number) {
+    try {
+      const data = await this.BoardsService.getOne(boardId)
+
+      return data
+    } catch (error) {
+      throw new BadRequestException(error.message)
+    }
+  }
 }
 

--- a/src/boards/boards.controller.ts
+++ b/src/boards/boards.controller.ts
@@ -30,6 +30,22 @@ export class BoardsController {
     }
   }
 
+
+  @Patch(":boardId/restoration")
+  async restore(@Param("boardId") boardId: number, @Headers("Authorization") Authorization: string) {
+    try {
+      if (!Authorization) {
+        throw new BadRequestException("로그인해주세요.")
+      }
+
+      const data = await this.BoardsService.restore(boardId, Authorization)
+
+      return data
+    } catch (error) {
+      throw new BadRequestException(error.message)
+    }
+  }
+
   @Patch(":boardId")
   async update(
     @Param("boardId") boardId: number,
@@ -64,3 +80,4 @@ export class BoardsController {
     }
   }
 }
+

--- a/src/boards/boards.module.ts
+++ b/src/boards/boards.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { SequelizeModule } from '@nestjs/sequelize';
+import { Boards } from './models/boards.model';
+import { BoardHashTags } from './models/board_hashTags.model';
+import { HashTags } from './models/hashTag.model';
+
+@Module({
+  imports: [
+    SequelizeModule.forFeature([Boards, HashTags, BoardHashTags])
+  ]
+})
+export class BoardsModule { }

--- a/src/boards/boards.module.ts
+++ b/src/boards/boards.module.ts
@@ -4,11 +4,13 @@ import { Boards } from './models/boards.model';
 import { BoardHashTags } from './models/board_hashTags.model';
 import { HashTags } from './models/hashTag.model';
 import { BoardsController } from './boards.controller';
+import { BoardsService } from './boards.service';
 
 @Module({
   imports: [
     SequelizeModule.forFeature([Boards, HashTags, BoardHashTags])
   ],
-  controllers: [BoardsController]
+  controllers: [BoardsController],
+  providers: [BoardsService]
 })
 export class BoardsModule { }

--- a/src/boards/boards.module.ts
+++ b/src/boards/boards.module.ts
@@ -5,10 +5,15 @@ import { BoardHashTags } from './models/board_hashTags.model';
 import { HashTags } from './models/hashTag.model';
 import { BoardsController } from './boards.controller';
 import { BoardsService } from './boards.service';
+import { JwtModule } from '@nestjs/jwt';
 
 @Module({
   imports: [
-    SequelizeModule.forFeature([Boards, HashTags, BoardHashTags])
+    SequelizeModule.forFeature([Boards, HashTags, BoardHashTags]),
+    JwtModule.register({
+      secret: process.env.SECRET,
+      signOptions: { expiresIn: '1d' },
+    }),
   ],
   controllers: [BoardsController],
   providers: [BoardsService]

--- a/src/boards/boards.module.ts
+++ b/src/boards/boards.module.ts
@@ -3,10 +3,12 @@ import { SequelizeModule } from '@nestjs/sequelize';
 import { Boards } from './models/boards.model';
 import { BoardHashTags } from './models/board_hashTags.model';
 import { HashTags } from './models/hashTag.model';
+import { BoardsController } from './boards.controller';
 
 @Module({
   imports: [
     SequelizeModule.forFeature([Boards, HashTags, BoardHashTags])
-  ]
+  ],
+  controllers: [BoardsController]
 })
 export class BoardsModule { }

--- a/src/boards/boards.service.ts
+++ b/src/boards/boards.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class BoardsService {}

--- a/src/boards/boards.service.ts
+++ b/src/boards/boards.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
+import { Injectable, BadRequestException, ShutdownSignal } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { BoardHashTags } from './models/board_hashTags.model';
 import { HashTags } from './models/hashTag.model';
@@ -209,5 +209,17 @@ export class BoardsService {
     })
 
     return boards
+  }
+
+  async getOne(boardId: number) {
+    const board = await this.boardModel.findByPk(boardId)
+    await this.boardModel.update({ views_count: board.views_count + 1 }, { where: { id: boardId } })
+
+    const newBoard = await this.boardModel.findByPk(boardId, {
+      attributes: {
+        exclude: ["user_id", "createdAt", "updatedAt", "deletedAt"]
+      }
+    })
+    return newBoard
   }
 }

--- a/src/boards/boards.service.ts
+++ b/src/boards/boards.service.ts
@@ -23,7 +23,13 @@ export class BoardsService {
 
     return await this.sequelize.transaction(async (transaction) => {
       const transactionHost = { transaction: transaction };
-      const board = await this.boardModel.create({ ...boardInfo, user_id: tokenInfo.id }, transactionHost);
+      const board = await this.boardModel.create({ ...boardInfo, user_id: tokenInfo.id },
+        {
+          raw: true,
+          ...transactionHost
+        }
+      );
+
       const hashTags = await Promise.all(boardInfo.hashTags.map(async (hashTag) => {
         const newHashTag = await this.hashTagsModel.findOrCreate({
           where: { name: hashTag },
@@ -43,7 +49,7 @@ export class BoardsService {
         await this.boardHashTagModel.create({ board_id: board.id, hashTag_id: hashTag.id }, transactionHost);
       }))
 
-      return { board: board, hashTags: hashTags }
+      return board
     })
   }
 

--- a/src/boards/boards.service.ts
+++ b/src/boards/boards.service.ts
@@ -1,24 +1,28 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { BoardHashTags } from './models/board_hashTags.model';
 import { HashTags } from './models/hashTag.model';
 import { Boards } from './models/boards.model';
 import { Sequelize } from 'sequelize-typescript';
 import { BoardInfoDTO } from './dto/boardInfo.dto';
+import { JwtService } from '@nestjs/jwt';
 
 @Injectable()
 export class BoardsService {
   constructor(
     private sequelize: Sequelize,
+    private jwtService: JwtService,
     @InjectModel(BoardHashTags) private boardHashTagModel: typeof BoardHashTags,
     @InjectModel(HashTags) private hashTagsModel: typeof HashTags,
     @InjectModel(Boards) private boardModel: typeof Boards,
   ) { }
 
-  async create(boardInfo: BoardInfoDTO) {
+  async create(boardInfo: BoardInfoDTO, Authorization: string) {
+    const tokenInfo = this.jwtService.verify(Authorization)
+
     return await this.sequelize.transaction(async (transaction) => {
       const transactionHost = { transaction: transaction };
-      const board = await this.boardModel.create(boardInfo, transactionHost);
+      const board = await this.boardModel.create({ ...boardInfo, user_id: tokenInfo.id }, transactionHost);
       const hashTags = await Promise.all(boardInfo.hashTags.map(async (hashTag) => {
         const newHashTag = await this.hashTagsModel.findOrCreate({
           where: { name: hashTag },

--- a/src/boards/boards.service.ts
+++ b/src/boards/boards.service.ts
@@ -4,6 +4,7 @@ import { BoardHashTags } from './models/board_hashTags.model';
 import { HashTags } from './models/hashTag.model';
 import { Boards } from './models/boards.model';
 import { Sequelize } from 'sequelize-typescript';
+import { BoardInfoDTO } from './dto/boardInfo.dto';
 
 @Injectable()
 export class BoardsService {
@@ -14,11 +15,11 @@ export class BoardsService {
     @InjectModel(Boards) private boardModel: typeof Boards,
   ) { }
 
-  async create(boardsInfo) {
+  async create(boardInfo: BoardInfoDTO) {
     return await this.sequelize.transaction(async (transaction) => {
       const transactionHost = { transaction: transaction };
-      const board = await this.boardModel.create(boardsInfo, transactionHost);
-      const hashTags = await Promise.all(boardsInfo.hashTags.map(async (hashTag) => {
+      const board = await this.boardModel.create(boardInfo, transactionHost);
+      const hashTags = await Promise.all(boardInfo.hashTags.map(async (hashTag) => {
         const newHashTag = await this.hashTagsModel.findOrCreate({
           where: { name: hashTag },
           attributes: {

--- a/src/boards/boards.service.ts
+++ b/src/boards/boards.service.ts
@@ -1,4 +1,43 @@
 import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/sequelize';
+import { BoardHashTags } from './models/board_hashTags.model';
+import { HashTags } from './models/hashTag.model';
+import { Boards } from './models/boards.model';
+import { Sequelize } from 'sequelize-typescript';
 
 @Injectable()
-export class BoardsService {}
+export class BoardsService {
+  constructor(
+    private sequelize: Sequelize,
+    @InjectModel(BoardHashTags) private boardHashTagModel: typeof BoardHashTags,
+    @InjectModel(HashTags) private hashTagsModel: typeof HashTags,
+    @InjectModel(Boards) private boardModel: typeof Boards,
+  ) { }
+
+  async create(boardsInfo) {
+    return await this.sequelize.transaction(async (transaction) => {
+      const transactionHost = { transaction: transaction };
+      const board = await this.boardModel.create(boardsInfo, transactionHost);
+      const hashTags = await Promise.all(boardsInfo.hashTags.map(async (hashTag) => {
+        const newHashTag = await this.hashTagsModel.findOrCreate({
+          where: { name: hashTag },
+          attributes: {
+            exclude: ["createdAt", "updatedAt", "deletedAt"]
+          },
+          raw: true,
+          ...transactionHost
+        });
+        const id = newHashTag[0].id;
+        const name = newHashTag[0].name;
+
+        return { id: id, name: name }
+      }))
+
+      hashTags.map(async (hashTag) => {
+        return await this.boardHashTagModel.create({ board_id: board.id, hashTag_id: hashTag.id }, transactionHost);
+      })
+
+      return { board: board, hashTags: hashTags }
+    })
+  }
+}

--- a/src/boards/boards.service.ts
+++ b/src/boards/boards.service.ts
@@ -33,9 +33,9 @@ export class BoardsService {
         return { id: id, name: name }
       }))
 
-      hashTags.map(async (hashTag) => {
-        return await this.boardHashTagModel.create({ board_id: board.id, hashTag_id: hashTag.id }, transactionHost);
-      })
+      await Promise.all(hashTags.map(async (hashTag) => {
+        await this.boardHashTagModel.create({ board_id: board.id, hashTag_id: hashTag.id }, transactionHost);
+      }))
 
       return { board: board, hashTags: hashTags }
     })

--- a/src/boards/dto/boardInfo.dto.ts
+++ b/src/boards/dto/boardInfo.dto.ts
@@ -1,0 +1,13 @@
+import { IsArray, IsString } from "class-validator";
+
+export class BoardInfoDTO {
+  @IsString()
+  readonly title: string;
+
+  @IsString()
+  readonly content: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  readonly hashTags: string[];
+}

--- a/src/boards/dto/queryInfo.dto.ts
+++ b/src/boards/dto/queryInfo.dto.ts
@@ -1,0 +1,22 @@
+import { IsNumber, IsString } from "class-validator";
+import { PartialType } from "@nestjs/mapped-types";
+
+class QueryDTO {
+  @IsString()
+  readonly search: string;
+
+  @IsString()
+  readonly orderBy: string;
+
+  @IsString()
+  readonly filter: string;
+
+  @IsNumber()
+  readonly page: number;
+
+  @IsNumber()
+  readonly limit: number;
+}
+
+
+export class QueryInfoDTO extends PartialType(QueryDTO) { }

--- a/src/boards/dto/updateBoardInfo.dto.ts
+++ b/src/boards/dto/updateBoardInfo.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from "@nestjs/mapped-types";
+import { BoardInfoDTO } from "./boardInfo.dto";
+
+export class UpdateBoardInfoDTO extends PartialType(BoardInfoDTO) { }

--- a/src/boards/models/board_hashTags.model.ts
+++ b/src/boards/models/board_hashTags.model.ts
@@ -15,10 +15,4 @@ export class BoardHashTags extends Model<BoardHashTags> {
   @Column
   @ForeignKey(() => HashTags)
   hashTag_id: number;
-
-  @BelongsTo(() => Boards)
-  boards: Boards
-
-  @BelongsTo(() => HashTags)
-  hashTags: HashTags
 }

--- a/src/boards/models/board_hashTags.model.ts
+++ b/src/boards/models/board_hashTags.model.ts
@@ -1,0 +1,24 @@
+import { Column, Model, Table, ForeignKey, BelongsTo } from 'sequelize-typescript';
+import { Boards } from './boards.model';
+import { HashTags } from './hashTag.model';
+
+@Table({
+  paranoid: true,
+  timestamps: true,
+  tableName: "board_hashTags"
+})
+export class BoardHashTags extends Model<BoardHashTags> {
+  @Column
+  @ForeignKey(() => Boards)
+  board_id: number;
+
+  @Column
+  @ForeignKey(() => HashTags)
+  hashTag_id: number;
+
+  @BelongsTo(() => Boards)
+  boards: Boards
+
+  @BelongsTo(() => HashTags)
+  hashTags: HashTags
+}

--- a/src/boards/models/boards.model.ts
+++ b/src/boards/models/boards.model.ts
@@ -19,6 +19,9 @@ export class Boards extends Model<Boards> {
   @ForeignKey(() => Users)
   user_id: number;
 
+  @Column
+  views_count: number;
+
   @BelongsToMany(() => HashTags, () => BoardHashTags)
   hashTags: HashTags[]
 

--- a/src/boards/models/boards.model.ts
+++ b/src/boards/models/boards.model.ts
@@ -1,4 +1,4 @@
-import { Column, Model, Table, HasMany, BelongsTo, ForeignKey } from 'sequelize-typescript';
+import { Column, Model, Table, BelongsToMany, BelongsTo, ForeignKey } from 'sequelize-typescript';
 import { Users } from 'src/users/users.model';
 import { BoardHashTags } from './board_hashTags.model';
 import { HashTags } from './hashTag.model';
@@ -19,8 +19,8 @@ export class Boards extends Model<Boards> {
   @ForeignKey(() => Users)
   user_id: number;
 
-  @HasMany(() => BoardHashTags)
-  boardHashTags: BoardHashTags[];
+  @BelongsToMany(() => HashTags, () => BoardHashTags)
+  hashTags: HashTags[]
 
   @BelongsTo(() => Users)
   users: Users

--- a/src/boards/models/boards.model.ts
+++ b/src/boards/models/boards.model.ts
@@ -1,4 +1,5 @@
 import { Column, Model, Table, HasMany } from 'sequelize-typescript';
+import { BoardHashTags } from './board_hashTags.model';
 import { HashTags } from './hashTag.model';
 
 @Table({
@@ -13,6 +14,6 @@ export class Boards extends Model<Boards> {
   @Column
   content: string;
 
-  @HasMany(() => HashTags)
-  hashTags: HashTags[];
+  @HasMany(() => BoardHashTags)
+  boardHashTags: BoardHashTags[];
 }

--- a/src/boards/models/boards.model.ts
+++ b/src/boards/models/boards.model.ts
@@ -1,0 +1,18 @@
+import { Column, Model, Table, HasMany } from 'sequelize-typescript';
+import { HashTags } from './hashTag.model';
+
+@Table({
+  paranoid: true,
+  timestamps: true,
+  tableName: "boards"
+})
+export class Boards extends Model<Boards> {
+  @Column
+  title: string;
+
+  @Column
+  content: string;
+
+  @HasMany(() => HashTags)
+  hashTags: HashTags[];
+}

--- a/src/boards/models/boards.model.ts
+++ b/src/boards/models/boards.model.ts
@@ -1,4 +1,5 @@
-import { Column, Model, Table, HasMany } from 'sequelize-typescript';
+import { Column, Model, Table, HasMany, BelongsTo, ForeignKey } from 'sequelize-typescript';
+import { Users } from 'src/users/users.model';
 import { BoardHashTags } from './board_hashTags.model';
 import { HashTags } from './hashTag.model';
 
@@ -14,6 +15,13 @@ export class Boards extends Model<Boards> {
   @Column
   content: string;
 
+  @Column
+  @ForeignKey(() => Users)
+  user_id: number;
+
   @HasMany(() => BoardHashTags)
   boardHashTags: BoardHashTags[];
+
+  @BelongsTo(() => Users)
+  users: Users
 }

--- a/src/boards/models/hashTag.model.ts
+++ b/src/boards/models/hashTag.model.ts
@@ -1,0 +1,15 @@
+import { Column, Model, Table, HasMany } from 'sequelize-typescript';
+import { Boards } from './boards.model';
+
+@Table({
+  paranoid: true,
+  timestamps: true,
+  tableName: "hashTags"
+})
+export class HashTags extends Model<HashTags> {
+  @Column
+  name: string;
+
+  @HasMany(() => Boards)
+  boards: Boards[];
+}

--- a/src/boards/models/hashTag.model.ts
+++ b/src/boards/models/hashTag.model.ts
@@ -1,4 +1,4 @@
-import { Column, Model, Table, HasMany } from 'sequelize-typescript';
+import { Column, Model, Table, BelongsToMany } from 'sequelize-typescript';
 import { Boards } from './boards.model';
 import { BoardHashTags } from './board_hashTags.model';
 
@@ -11,6 +11,6 @@ export class HashTags extends Model<HashTags> {
   @Column
   name: string;
 
-  @HasMany(() => BoardHashTags)
-  boardHashTags: BoardHashTags[];
+  @BelongsToMany(() => Boards, () => BoardHashTags)
+  boards: Boards[]
 }

--- a/src/boards/models/hashTag.model.ts
+++ b/src/boards/models/hashTag.model.ts
@@ -1,5 +1,6 @@
 import { Column, Model, Table, HasMany } from 'sequelize-typescript';
 import { Boards } from './boards.model';
+import { BoardHashTags } from './board_hashTags.model';
 
 @Table({
   paranoid: true,
@@ -10,6 +11,6 @@ export class HashTags extends Model<HashTags> {
   @Column
   name: string;
 
-  @HasMany(() => Boards)
-  boards: Boards[];
+  @HasMany(() => BoardHashTags)
+  boardHashTags: BoardHashTags[];
 }

--- a/src/database/migrations/20220929021836-boards.js
+++ b/src/database/migrations/20220929021836-boards.js
@@ -1,0 +1,39 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return await queryInterface.createTable('boards', {
+      id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        autoIncrement: true,
+        unique: true,
+        primaryKey: true,
+      },
+      title: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      content: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      deletedAt: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return await queryInterface.dropTable('boards');
+  },
+};

--- a/src/database/migrations/20220929021836-boards.js
+++ b/src/database/migrations/20220929021836-boards.js
@@ -26,6 +26,10 @@ module.exports = {
           key: 'id',
         },
       },
+      views_count: {
+        type: Sequelize.INTEGER,
+        defaultValue: 0,
+      },
       createdAt: {
         type: Sequelize.DATE,
         allowNull: false,

--- a/src/database/migrations/20220929021836-boards.js
+++ b/src/database/migrations/20220929021836-boards.js
@@ -18,6 +18,14 @@ module.exports = {
         type: Sequelize.STRING,
         allowNull: false,
       },
+      user_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'users',
+          key: 'id',
+        },
+      },
       createdAt: {
         type: Sequelize.DATE,
         allowNull: false,

--- a/src/database/migrations/20220929022142-hashTags.js
+++ b/src/database/migrations/20220929022142-hashTags.js
@@ -1,0 +1,35 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return await queryInterface.createTable('hashTags', {
+      id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        autoIncrement: true,
+        unique: true,
+        primaryKey: true,
+      },
+      name: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      deletedAt: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return await queryInterface.dropTable('hashTags');
+  },
+};

--- a/src/database/migrations/20220929022318-board-hashTags.js
+++ b/src/database/migrations/20220929022318-board-hashTags.js
@@ -1,0 +1,47 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return await queryInterface.createTable('board_hashTags', {
+      id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        autoIncrement: true,
+        unique: true,
+        primaryKey: true,
+      },
+      board_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'boards',
+          key: 'id',
+        },
+      },
+      hashTag_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'hashTags',
+          key: 'id',
+        },
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      deletedAt: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return await queryInterface.dropTable('board_hashTags');
+  },
+};

--- a/src/users/users.model.ts
+++ b/src/users/users.model.ts
@@ -1,4 +1,5 @@
-import { Column, Model, Table } from 'sequelize-typescript';
+import { Column, Model, Table, HasMany } from 'sequelize-typescript';
+import { Boards } from 'src/boards/models/boards.model';
 
 @Table({
   paranoid: true,
@@ -8,4 +9,7 @@ import { Column, Model, Table } from 'sequelize-typescript';
 export class Users extends Model<Users> {
   @Column
   email: string;
+
+  @HasMany(() => Boards)
+  boards: Boards[];
 }


### PR DESCRIPTION
## 내용
- 게시글 CRUD API 추가했습니다.
- 게시글 삭제시 복원 API 추가했습니다.
- 작성자만 생성, 수정, 삭제 할 수 있습니다.(누구든지 볼 수 있습니다.)
- 게시글을 본다면 조회수가 올라갑니다.
- 좋아요를 구현하지 못했습니다.
- 게시글 목록을 조회할때, 검색/정렬/필터링/페이지네이션이 동시에 적용되어야합니다.(아직 각각 동작하지 않습니다.)